### PR TITLE
feat: add feature flags

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,20 +11,28 @@ edition = "2018"
 [[bin]]
 name = "changelog"
 path = "src/bin/changelog.rs"
+required-features = ["cli"]
 
 [dependencies]
 chrono = "0.4.13"
 conventional-commits-next-semver = "0.1.1"
 conventional-commits-parser = "0.1.1"
 git2 = "0.13.8"
-indoc = "1.0.2"
+indoc = { version = "1.0.2", optional = true }
 markdown-composer = "0.1.0"
-pico-args = { version = "0.3.4", default-features = false }
+pico-args = { version = "0.3.4", default-features = false, optional = true }
 semver = "0.10.0"
 inventory = "0.1.7"
 url = "2.1.1"
-cargo_toml = "0.8.1"
+cargo_toml = { version = "0.8.1", optional = true }
 thiserror = "1.0.20"
+
+[features]
+default = ["extractors"]
+cli = ["indoc", "pico-args"]
+extractors = ["extractor-cargo", "extractor-git"]
+extractor-cargo = ["cargo_toml"]
+extractor-git = []
 
 [patch.crates-io]
 conventional-commits-parser = { path = "../conventional-commits-parser" }

--- a/README.md
+++ b/README.md
@@ -9,8 +9,10 @@
 
 ## Installation
 
+The library can be added to your project as usual. If you want to install the binary, then please run this command:
+
 ```text
-cargo install conventional-commits-changelog-generator --locked
+cargo install conventional-commits-changelog-generator --locked --features cli
 ```
 
 ## License

--- a/src/extractors/mod.rs
+++ b/src/extractors/mod.rs
@@ -1,6 +1,8 @@
 use std::path::Path;
 
+#[cfg(feature = "extractor-cargo")]
 mod cargo;
+#[cfg(feature = "extractor-git")]
 mod git;
 mod utils;
 


### PR DESCRIPTION
This commit adds feature flags for the CLI and all extractors. Each
extractor is now behind its own feature flag, allowing compilation with
or without it.

Closes #9